### PR TITLE
[FIX] sql injection using loglines

### DIFF
--- a/samples/fail2ban/bin/fail2ban_banned_db
+++ b/samples/fail2ban/bin/fail2ban_banned_db
@@ -109,7 +109,7 @@ if [[ X"${_action}" == X"ban" ]]; then
     shift 6
     _rest="$@"
     # Avoid SQL injection.
-    printf -v _loglines "${_rest}"
+    printf -v _loglines "${_rest//\'/\'\'}"
 
     if [[ X"${_ip}" == X'' ]] || \
         [[ X"${_ports}" == X'' ]] || \


### PR DESCRIPTION
Fixes sql injection using single quotes in `loglines`.

* Example:
A log line containing this ...
``` 
Login by '); drop table banned; select concat(' failed
```
... would drop the table `banned`.