### PR TITLE
Drops Debian 9 from the supported distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ iRedMail is a full-featured mail server solution. It supports few mainstream
 Linux/BSD distributions:
 
 - CentOS 7, 8
-- Debian 10 (recommended), 9
+- Debian 10
 - Ubuntu 18.04, 20.04
 - FreeBSD 12.x
 - OpenBSD 6.7


### PR DESCRIPTION
Drops Debian 9 from the supported Linux/BSD distributions list.