### PR TITLE
Fix fail2ban action for nftables

### DIFF
--- a/conf/fail2ban
+++ b/conf/fail2ban
@@ -49,7 +49,7 @@ export FAIL2BAN_SYSLOG_FACILITY='daemon'
 if [ X"${KERNEL_NAME}" == X'LINUX' ]; then
     export FAIL2BAN_ACTION='iptables-multiport'
 
-    if [ X"${DISTRO_CODENAME}" == X'buster' ]; then
+    if [ X"${DISTRO}" == X'DEBIAN' -o X"${DISTRO}" == X'UBUNTU' ]; then
         export FAIL2BAN_ACTION='nftables-multiport'
     fi
 elif [ X"${KERNEL_NAME}" == X'FREEBSD' ]; then


### PR DESCRIPTION
Global config sets up nftables for Debian and Ubuntu https://github.com/iredmail/iRedMail/blob/master/conf/global#L493, but the correct fail2ban action was set only for Debian Buster. 