### PR TITLE
roundcubemail增加PGP端到端加密功能

### DIFF
--- a/samples/roundcubemail/config.inc.php
+++ b/samples/roundcubemail/config.inc.php
@@ -67,5 +67,5 @@ $config['layout'] = 'widescreen';   // three columns
 //$config['skip_deleted'] = true;
 
 // PLUGINS
-$config['plugins'] = array('managesieve', 'password', 'zipdownload');
+$config['plugins'] = array('managesieve', 'password', 'zipdownload''enigma','userinfo');
 


### PR DESCRIPTION
roundcubemail增加PGP端到端加密功能，方便用户使用PGP端到端加密收发邮件，避免中间商查看邮箱内容或拿去喂大数据。