### PR TITLE
fix: mitigate SMTP smuggling

### DIFF
--- a/samples/postfix/main.cf
+++ b/samples/postfix/main.cf
@@ -276,3 +276,6 @@ recipient_delimiter = +
 # The extra detail makes trouble shooting easier but also reveals information
 # that is nobody elses business.
 show_user_unknown_table_name = no
+
+# Mitigate Postfix SMTP smuggling attack by rejecting RFC 2920/5321 violations
+smtpd_forbid_unauth_pipelining = yes

--- a/samples/postfix/main.cf
+++ b/samples/postfix/main.cf
@@ -279,3 +279,4 @@ show_user_unknown_table_name = no
 
 # Mitigate Postfix SMTP smuggling attack by rejecting RFC 2920/5321 violations
 smtpd_forbid_unauth_pipelining = yes
+smtpd_discard_ehlo_keywords = chunking

--- a/samples/postfix/main.cf
+++ b/samples/postfix/main.cf
@@ -278,5 +278,4 @@ recipient_delimiter = +
 show_user_unknown_table_name = no
 
 # Mitigate Postfix SMTP smuggling attack by rejecting RFC 2920/5321 violations
-smtpd_forbid_unauth_pipelining = yes
 smtpd_discard_ehlo_keywords = chunking


### PR DESCRIPTION
This PR applies mitigations recommended by postfix to mitigate an SMTP smuggling vulnerability, allowing an attacker to send spoofed emails.

https://www.postfix.org/smtp-smuggling.html