### PR TITLE
Wrong column name for fail2ban stop/cleanup action

### DIFF
--- a/samples/fail2ban/bin/fail2ban_banned_db
+++ b/samples/fail2ban/bin/fail2ban_banned_db
@@ -231,7 +231,7 @@ elif [[ X"${_action}" == X'stop' ]] || [[ X"${_action}" == X"cleanup" ]]; then
     if [[ X"${_jail}" != X'' ]]; then
         ${CMD_SQL} >/dev/null <<EOF
 DELETE FROM ${DB_TABLE_BANNED} WHERE jail='${_jail}';
-DELETE FROM ${DB_TABLE_JAILS} WHERE jail='${_jail}';
+DELETE FROM ${DB_TABLE_JAILS} WHERE name='${_jail}';
 EOF
     fi
 


### PR DESCRIPTION
I found this issue while following the upgrade steps on https://docs.iredmail.org/upgrade.iredmail.1.6.8-1.7.0.html

The `jails` table has a column `name` but not `jail` (https://github.com/iredmail/iRedMail/blob/master/update/1.7.0/fail2ban.mysql#L6)